### PR TITLE
Remove unused cleanup targets

### DIFF
--- a/NewNoteControl/Library/ContainerProvider.swift
+++ b/NewNoteControl/Library/ContainerProvider.swift
@@ -7,12 +7,6 @@
 
 import WidgetKit
 
-/*
- I wrote the initial TimelineProvider, but had ChatGPT refactor it so we could have different
- providers for different NoteContainers. Everything was the same for every NoteContainer except
- how we select it from the list of NoteContainers. So, this allows us to re-use this code but
- change the selection logic per-container
-*/
 protocol ContainerSpec {
     // Pick which container to show from your snapshot
     static func select(from snapshot: Snapshot) -> NoteContainerSnapshot?
@@ -20,13 +14,11 @@ protocol ContainerSpec {
     // Optional: fallbacks for placeholder/meta if snapshot is missing fields
     static var placeholderName: String { get }
     static var placeholderSymbol: String { get }
-    static var placeholderColor: UInt32 { get }
 }
 
 extension ContainerSpec {
     static var placeholderName: String { "TakeNote" }
     static var placeholderSymbol: String { "text.pad" }
-    static var placeholderColor: UInt32 { 0x000000 }
 }
 
 struct ContainerProvider<Spec: ContainerSpec>: TimelineProvider {
@@ -48,7 +40,6 @@ struct ContainerProvider<Spec: ContainerSpec>: TimelineProvider {
             isPlaceholder: true,
             name: Spec.placeholderName,
             symbol: Spec.placeholderSymbol,
-            color: Spec.placeholderColor,
             totalNoteCount: 0
         )
     }
@@ -84,7 +75,6 @@ struct ContainerProvider<Spec: ContainerSpec>: TimelineProvider {
             isPlaceholder: false,
             name: container.name,
             symbol: container.symbol,
-            color: container.color,
             totalNoteCount: container.totalNoteCount
         )
 

--- a/NewNoteControl/Library/NoteListEntry.swift
+++ b/NewNoteControl/Library/NoteListEntry.swift
@@ -22,6 +22,5 @@ struct NoteListEntry: TimelineEntry {
     let isPlaceholder: Bool
     let name: String
     let symbol: String
-    let color: UInt32
     let totalNoteCount: Int
 }

--- a/TakeNote/Library/SnapshotController.swift
+++ b/TakeNote/Library/SnapshotController.swift
@@ -22,16 +22,13 @@ struct NoteContainerSnapshot: Codable, Identifiable, Hashable {
     var name: String
     var notes: [NoteSnapshot]
     var symbol: String
-    var color: UInt32
     var isInbox: Bool = false
     var isStarred: Bool = false
-    var isTag: Bool = false
     var totalNoteCount: Int = 0
 }
 
 struct Snapshot: Codable, Identifiable, Hashable {
     var id: UUID
-    var generatedAt: Date
     var containers: [NoteContainerSnapshot]
 }
 
@@ -45,7 +42,7 @@ class SnapshotController {
             .appendingPathComponent(filename)
     }
 
-    public static func readSnapshot() -> Snapshot? {
+    static func readSnapshot() -> Snapshot? {
         guard let data = try? Data(contentsOf: snapshotFileURL) else {
             return nil
         }
@@ -66,7 +63,7 @@ class SnapshotController {
         }
     }
 
-    public static func takeSnapshot(modelContext: ModelContext) {
+    static func takeSnapshot(modelContext: ModelContext) {
         #if DEBUG
         print("Taking snapshot...")
         #endif
@@ -101,10 +98,8 @@ class SnapshotController {
                 name: container.name,
                 notes: noteSnapshots,
                 symbol: container.symbol,
-                color: container.colorRGBA,
                 isInbox: container.isInbox,
                 isStarred: container.isStarred,
-                isTag: container.isTag,
                 totalNoteCount: container.notes.count
             )
 
@@ -114,7 +109,6 @@ class SnapshotController {
         // Build and write the full snapshot
         let snapshot = Snapshot(
             id: UUID(),
-            generatedAt: Date(),
             containers: containerSnapshots
         )
         Self.writeSnapshotFile(snapshot)

--- a/TakeNote/Views/MainWindow/MainWindow.swift
+++ b/TakeNote/Views/MainWindow/MainWindow.swift
@@ -31,10 +31,7 @@ struct MainWindow: View {
 
     @State private var notesInBufferMessagePresented: Bool = false
     @State private var showDeleteEverythingAlert: Bool = false
-
     @State private var preferredColumn = NavigationSplitViewColumn.sidebar
-
-    @State private var showChatPopover: Bool = false
     @State private var showSidebarChatPopover: Bool = false
     @State private var showSortPopover: Bool = false
 
@@ -50,11 +47,6 @@ struct MainWindow: View {
     func showDeleteEverything() {
         showDeleteEverythingAlert = true
     }
-
-    func doShowChatPopover() {
-        showChatPopover.toggle()
-    }
-
     func doShowSidebarChatPopover() {
         showSidebarChatPopover.toggle()
     }
@@ -131,7 +123,6 @@ struct MainWindow: View {
             }
         }
     }
-
     var navTitle: String {
         #if os(iOS)
             if UIDevice.current.userInterfaceIdiom == .phone {

--- a/TakeNote/Views/TagList/TagList.swift
+++ b/TakeNote/Views/TagList/TagList.swift
@@ -15,7 +15,7 @@ internal struct TagList: View {
         }
     ) var tags: [NoteContainer]
 
-    public var body: some View {
+    var body: some View {
         ForEach(tags, id: \.self) { tag in
             TagListEntry(tag: tag)
         }


### PR DESCRIPTION
Prune dead widget snapshot plumbing, unused chat popover state, and redundant public access found during deterministic Periphery cleanup.

Generated with OpenAI Codex.